### PR TITLE
Supporting enabling/disabling of listeners via mqtt

### DIFF
--- a/Mqtt/src/com/github/pfichtner/ardulink/AbstractMqttAdapter.java
+++ b/Mqtt/src/com/github/pfichtner/ardulink/AbstractMqttAdapter.java
@@ -13,15 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-*/
+ */
 package com.github.pfichtner.ardulink;
 
 import static com.github.pfichtner.ardulink.util.Preconditions.checkArgument;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
 import static org.zu.ardulink.protocol.IProtocol.POWER_HIGH;
 import static org.zu.ardulink.protocol.IProtocol.POWER_LOW;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -110,21 +115,75 @@ public abstract class AbstractMqttAdapter {
 
 	}
 
+	/**
+	 * Does handle mqtt messages for controlling Ardulink (start/stop
+	 * listeners).
+	 */
+	private static class ControlHandler implements Handler {
+
+		private final Link link;
+		private final Pattern pattern;
+
+		public ControlHandler(Link link, Config config) {
+			this.link = link;
+			this.pattern = config.getTopicPatternControl();
+		}
+
+		@Override
+		public boolean handle(String topic, String message) {
+			Matcher matcher = pattern.matcher(topic);
+			if (matcher.matches()) {
+				String type = matcher.group(1);
+				Integer pin = tryParse(matcher.group(2));
+				if (pin != null) {
+					boolean state = parseBoolean(message);
+					if ("D".equalsIgnoreCase(type)) {
+						if (state) {
+							this.link.startListenDigitalPin(pin);
+						} else {
+							this.link.stopListenDigitalPin(pin);
+						}
+					}
+					if (type.equalsIgnoreCase("A")) {
+						if (state) {
+							this.link.startListenAnalogPin(pin);
+						} else {
+							this.link.stopListenAnalogPin(pin);
+						}
+					}
+					return true;
+				}
+			}
+			return false;
+		}
+
+	}
+
 	private final Link link;
 
 	private final Config config;
 
-	private final Handler[] handlers;
+	private final List<Handler> handlers;
 
 	public AbstractMqttAdapter(Link link, Config config) {
-		this(link, config, new Handler[] { new DigitalHandler(link, config),
-				new AnalogHandler(link, config) });
+		this(link, config, handlers(link, config));
 	}
 
-	public AbstractMqttAdapter(Link link, Config config, Handler[] handlers) {
+	protected static List<Handler> handlers(Link link, Config config) {
+		List<Handler> handlers = new ArrayList<Handler>(Arrays.asList(
+				new DigitalHandler(link, config), new AnalogHandler(link,
+						config)));
+		if (config.getTopicPatternControl() != null) {
+			handlers.add(new ControlHandler(link, config));
+		}
+		return handlers;
+	}
+
+	public AbstractMqttAdapter(Link link, Config config,
+			Collection<Handler> handlers) {
 		this.link = link;
 		this.config = config;
-		this.handlers = handlers.clone();
+		this.handlers = unmodifiableList(new ArrayList<Handler>(handlers));
 	}
 
 	/**

--- a/Mqtt/src/com/github/pfichtner/ardulink/Config.java
+++ b/Mqtt/src/com/github/pfichtner/ardulink/Config.java
@@ -57,8 +57,14 @@ public abstract class Config {
 			return delegate.getTopicPatternAnalogRead();
 		}
 
-		public Pattern getTopicPatternControl() {
-			return delegate.getTopicPatternControl();
+		@Override
+		public Pattern getTopicPatternDigitalControl() {
+			return delegate.getTopicPatternDigitalControl();
+		}
+
+		@Override
+		public Pattern getTopicPatternAnalogControl() {
+			return delegate.getTopicPatternAnalogControl();
 		}
 
 	}
@@ -81,20 +87,6 @@ public abstract class Config {
 				this.topicPatternDigitalRead = read(topic, "D");
 				this.topicPatternAnalogWrite = compile(write(topic, "A"));
 				this.topicPatternAnalogRead = read(topic, "A");
-			}
-
-			private String read(String brokerTopic, String prefix) {
-				return format(brokerTopic, prefix, "%s", "/get");
-			}
-
-			private String write(String brokerTopic, String prefix) {
-				return format(brokerTopic, prefix, "(\\w+)", "/set");
-			}
-
-			private String format(String brokerTopic, String prefix,
-					String numerated, String appendix) {
-				return brokerTopic + prefix
-						+ String.format("%s/value", numerated) + appendix;
 			}
 
 			@Override
@@ -123,7 +115,12 @@ public abstract class Config {
 			}
 
 			@Override
-			public Pattern getTopicPatternControl() {
+			public Pattern getTopicPatternDigitalControl() {
+				return null;
+			}
+
+			@Override
+			public Pattern getTopicPatternAnalogControl() {
 				return null;
 			}
 
@@ -133,14 +130,37 @@ public abstract class Config {
 	public Config withControlChannelEnabled() {
 		return new ConfigDelegate(this) {
 
-			private final Pattern topicPatternControl = compile(getTopic()
-					+ "system\\/listening\\/(.)(\\w+)\\/value\\/set");
+			private final Pattern topicPatternDigitalControl = compile(write(
+					getTopic() + "system/listening/", "D"));
+
+			private final Pattern topicPatternAnalogControl = compile(write(
+					getTopic() + "system/listening/", "A"));
 
 			@Override
-			public Pattern getTopicPatternControl() {
-				return topicPatternControl;
+			public Pattern getTopicPatternDigitalControl() {
+				return topicPatternDigitalControl;
 			}
+
+			@Override
+			public Pattern getTopicPatternAnalogControl() {
+				return topicPatternAnalogControl;
+			}
+
 		};
+	}
+
+	private static String read(String brokerTopic, String prefix) {
+		return format(brokerTopic, prefix, "%s", "/get");
+	}
+
+	private static String write(String brokerTopic, String prefix) {
+		return format(brokerTopic, prefix, "(\\w+)", "/set");
+	}
+
+	private static String format(String brokerTopic, String prefix,
+			String numerated, String appendix) {
+		return brokerTopic + prefix + String.format("%s/value", numerated)
+				+ appendix;
 	}
 
 	protected abstract String getTopic();
@@ -153,6 +173,8 @@ public abstract class Config {
 
 	public abstract String getTopicPatternAnalogRead();
 
-	public abstract Pattern getTopicPatternControl();
+	public abstract Pattern getTopicPatternDigitalControl();
+
+	public abstract Pattern getTopicPatternAnalogControl();
 
 }

--- a/Mqtt/src/com/github/pfichtner/ardulink/Config.java
+++ b/Mqtt/src/com/github/pfichtner/ardulink/Config.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-*/
+ */
 package com.github.pfichtner.ardulink;
 
 import static java.util.regex.Pattern.compile;
@@ -28,13 +28,49 @@ import java.util.regex.Pattern;
  */
 public abstract class Config {
 
+	private static class ConfigDelegate extends Config {
+
+		private final Config delegate;
+
+		public ConfigDelegate(Config delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		protected String getTopic() {
+			return delegate.getTopic();
+		}
+
+		public Pattern getTopicPatternDigitalWrite() {
+			return delegate.getTopicPatternDigitalWrite();
+		}
+
+		public Pattern getTopicPatternAnalogWrite() {
+			return delegate.getTopicPatternAnalogWrite();
+		}
+
+		public String getTopicPatternDigitalRead() {
+			return delegate.getTopicPatternDigitalRead();
+		}
+
+		public String getTopicPatternAnalogRead() {
+			return delegate.getTopicPatternAnalogRead();
+		}
+
+		public Pattern getTopicPatternControl() {
+			return delegate.getTopicPatternControl();
+		}
+
+	}
+
 	public static final String DEFAULT_TOPIC = "home/devices/ardulink/";
 
 	public static final Config DEFAULT = withTopic(DEFAULT_TOPIC);
 
-	public static Config withTopic(final String topic) {
+	public static Config withTopic(final String withTopic) {
 		return new Config() {
 
+			private String topic = withTopic;
 			private final Pattern topicPatternDigitalWrite;
 			private final String topicPatternDigitalRead;
 			private final Pattern topicPatternAnalogWrite;
@@ -62,6 +98,11 @@ public abstract class Config {
 			}
 
 			@Override
+			protected String getTopic() {
+				return topic;
+			}
+
+			@Override
 			public Pattern getTopicPatternDigitalWrite() {
 				return topicPatternDigitalWrite;
 			}
@@ -81,8 +122,28 @@ public abstract class Config {
 				return topicPatternAnalogRead;
 			}
 
+			@Override
+			public Pattern getTopicPatternControl() {
+				return null;
+			}
+
 		};
 	}
+
+	public Config withControlChannelEnabled() {
+		return new ConfigDelegate(this) {
+
+			private final Pattern topicPatternControl = compile(getTopic()
+					+ "system\\/listening\\/(.)(\\w+)\\/value\\/set");
+
+			@Override
+			public Pattern getTopicPatternControl() {
+				return topicPatternControl;
+			}
+		};
+	}
+
+	protected abstract String getTopic();
 
 	public abstract Pattern getTopicPatternDigitalWrite();
 
@@ -91,5 +152,7 @@ public abstract class Config {
 	public abstract String getTopicPatternDigitalRead();
 
 	public abstract String getTopicPatternAnalogRead();
+
+	public abstract Pattern getTopicPatternControl();
 
 }

--- a/Mqtt/src/com/github/pfichtner/ardulink/MqttMain.java
+++ b/Mqtt/src/com/github/pfichtner/ardulink/MqttMain.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-*/
+ */
 package com.github.pfichtner.ardulink;
 
 import static com.github.pfichtner.ardulink.AbstractMqttAdapter.CompactStrategy.AVERAGE;
@@ -84,6 +84,9 @@ public class MqttMain {
 
 	@Option(name = "-remote", usage = "Host (and optional port) of a remote ardulink arduino")
 	private String remote;
+
+	@Option(name = "-control", usage = "Enable the control of listeners via mqtt")
+	private boolean control;
 
 	private MqttClient mqttClient;
 
@@ -267,7 +270,9 @@ public class MqttMain {
 		this.link = connect(createLink());
 		// ensure brokerTopic is normalized
 		setBrokerTopic(this.brokerTopic);
-		mqttClient = new MqttClient(link, Config.withTopic(this.brokerTopic))
+		Config config = Config.withTopic(this.brokerTopic);
+		mqttClient = new MqttClient(link,
+				this.control ? config.withControlChannelEnabled() : config)
 				.listenToMqttAndArduino();
 	}
 

--- a/Mqtt/test/com/github/pfichtner/ardulink/ControlChannelTest.java
+++ b/Mqtt/test/com/github/pfichtner/ardulink/ControlChannelTest.java
@@ -1,0 +1,194 @@
+/**
+Copyright 2013 project Ardulink http://www.ardulink.org/
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ */
+package com.github.pfichtner.ardulink;
+
+import static com.github.pfichtner.ardulink.util.MqttMessageBuilder.mqttMessageWithBasicTopic;
+import static com.github.pfichtner.ardulink.util.ProtoBuilder.alpProtocolMessage;
+import static com.github.pfichtner.ardulink.util.ProtoBuilder.ALPProtocolKeys.START_LISTENING_ANALOG;
+import static com.github.pfichtner.ardulink.util.ProtoBuilder.ALPProtocolKeys.START_LISTENING_DIGITAL;
+import static com.github.pfichtner.ardulink.util.ProtoBuilder.ALPProtocolKeys.STOP_LISTENING_ANALOG;
+import static com.github.pfichtner.ardulink.util.ProtoBuilder.ALPProtocolKeys.STOP_LISTENING_DIGITAL;
+import static com.github.pfichtner.ardulink.util.TestUtil.createConnection;
+import static com.github.pfichtner.ardulink.util.TestUtil.getField;
+import static com.github.pfichtner.ardulink.util.TestUtil.set;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.zu.ardulink.ConnectionContactImpl;
+import org.zu.ardulink.Link;
+import org.zu.ardulink.connection.Connection;
+import org.zu.ardulink.connection.ConnectionContact;
+
+import com.github.pfichtner.ardulink.util.Message;
+import com.github.pfichtner.ardulink.util.MqttMessageBuilder;
+
+/**
+ * [ardulinktitle] [ardulinkversion]
+ * 
+ * @author Peter Fichtner
+ * 
+ *         [adsense]
+ */
+public class ControlChannelTest {
+
+	private static final String LINKNAME = "testlink";
+
+	private final List<Message> published = new ArrayList<Message>();
+
+	private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+	private final ConnectionContact connectionContact = new ConnectionContactImpl(
+			null);
+	private final Connection connection = createConnection(outputStream,
+			connectionContact);
+	private final Link link = Link.createInstance(LINKNAME, connection);
+
+	private final AbstractMqttAdapter mqttClient = new AbstractMqttAdapter(
+			link, Config.DEFAULT.withControlChannelEnabled()) {
+		@Override
+		void fromArduino(String topic, String message) {
+			published.add(new Message(topic, message));
+		}
+	};
+
+	private final MqttMessageBuilder mqttMessage = mqttMessageWithBasicTopic(Config.DEFAULT_TOPIC);
+
+	{
+		// there is an extremely high coupling of ConnectionContactImpl and Link
+		// which can not be solved other than injecting the variables through
+		// reflection
+		set(connectionContact, getField(connectionContact, "link"), link);
+		set(link, getField(link, "connectionContact"), connectionContact);
+
+	}
+
+	@Before
+	public void setup() {
+		link.connect();
+	}
+
+	@After
+	public void tearDown() {
+		link.disconnect();
+		Link.destroyInstance(LINKNAME);
+	}
+
+	@Test
+	public void canEnableListenerForDigitalPin() {
+		int pin = 2;
+		simulateMqttToArduino(mqttMessage.digitalListener(pin).enable());
+		assertThat(serialReceived(),
+				is(alpProtocolMessage(START_LISTENING_DIGITAL).forPin(pin)
+						.withoutValue()));
+	}
+
+	@Test
+	public void noMessageWhenConfigDoesNotSupportControlChannel() {
+		int pin = 2;
+		Message message = mqttMessage.digitalListener(pin).enable();
+		new AbstractMqttAdapter(link, Config.DEFAULT) {
+			@Override
+			void fromArduino(String topic, String message) {
+				published.add(new Message(topic, message));
+			}
+		}.toArduino(message.getTopic(), message.getMessage());
+		assertThat(serialReceived(), is(empty()));
+	}
+
+	@Test
+	public void canEnableListenerForAnalogPin() {
+		int pin = 3;
+		simulateMqttToArduino(mqttMessage.analogListener(pin).enable());
+		assertThat(serialReceived(),
+				is(alpProtocolMessage(START_LISTENING_ANALOG).forPin(pin)
+						.withoutValue()));
+	}
+
+	@Test
+	public void canDisableListenerForDigitalPin() {
+		int pin = 4;
+		simulateMqttToArduino(mqttMessage.digitalListener(pin).disable());
+		assertThat(serialReceived(),
+				is(alpProtocolMessage(STOP_LISTENING_DIGITAL).forPin(pin)
+						.withoutValue()));
+	}
+
+	@Test
+	public void canDisableListenerForAnalogPin() {
+		int pin = 5;
+		simulateMqttToArduino(mqttMessage.analogListener(pin).disable());
+		assertThat(serialReceived(),
+				is(alpProtocolMessage(STOP_LISTENING_ANALOG).forPin(pin)
+						.withoutValue()));
+	}
+
+	@Test
+	public void canHandleInvaldTypeOnEnabling() {
+		int pin = 6;
+		simulateMqttToArduino(mqttMessage.listener().appendTopic("X" + pin)
+				.enable());
+		assertThat(serialReceived(), is(empty()));
+	}
+
+	@Test
+	public void canHandleInvaldTypeOnDisabling() {
+		int pin = 6;
+		simulateMqttToArduino(mqttMessage.listener().appendTopic("X" + pin)
+				.disable());
+		assertThat(serialReceived(), is(empty()));
+	}
+
+	@Test
+	public void canHandleInvaldDigitalPins() {
+		String pin = "X";
+		simulateMqttToArduino(mqttMessage.listener().appendTopic("D" + pin)
+				.enable());
+		assertThat(serialReceived(), is(empty()));
+	}
+
+	@Test
+	public void canHandleInvaldAnalogPins() {
+		String pin = "X";
+		simulateMqttToArduino(mqttMessage.listener().appendTopic("A" + pin)
+				.enable());
+		assertThat(serialReceived(), is(empty()));
+	}
+
+	private void simulateMqttToArduino(Message message) {
+		mqttClient.toArduino(message.getTopic(), message.getMessage());
+	}
+
+	private String serialReceived() {
+		try {
+			outputStream.close();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		return new String(outputStream.toByteArray());
+	}
+
+	private static String empty() {
+		return "";
+	}
+}

--- a/Mqtt/test/com/github/pfichtner/ardulink/MqttAdapterTest.java
+++ b/Mqtt/test/com/github/pfichtner/ardulink/MqttAdapterTest.java
@@ -99,15 +99,15 @@ public class MqttAdapterTest {
 	@Test
 	public void canPowerOnDigitalPin() {
 		int pin = 0;
-		simulateMqttToArduino(mqttMessage.digitalPin(pin).setValue(true));
+		simulateMqttToArduino(mqttMessage.digitalPin(pin).enable());
 		assertThat(serialReceived(), is(alpProtocolMessage(POWER_PIN_SWITCH)
 				.forPin(pin).withValue(1)));
 	}
 
 	@Test
 	public void canHandleInvalidTopics() {
-		simulateMqttToArduino(mqttMessage.withSubTopic(
-				"xxxxxxxxINVALID_TOPICxxxxxxxx").setValue(true));
+		simulateMqttToArduino(mqttMessage.appendTopic(
+				"xxxxxxxxINVALID_TOPICxxxxxxxx").enable());
 		assertThat(serialReceived(), is(empty()));
 	}
 

--- a/Mqtt/test/com/github/pfichtner/ardulink/util/ProtoBuilder.java
+++ b/Mqtt/test/com/github/pfichtner/ardulink/util/ProtoBuilder.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-*/
+ */
 package com.github.pfichtner.ardulink.util;
 
 import static com.github.pfichtner.ardulink.util.Preconditions.checkArgument;
@@ -32,7 +32,9 @@ public class ProtoBuilder {
 	public enum ALPProtocolKeys {
 
 		POWER_PIN_SWITCH("ppsw"), POWER_PIN_INTENSITY("ppin"), DIGITAL_PIN_READ(
-				"dred"), ANALOG_PIN_READ("ared");
+				"dred"), ANALOG_PIN_READ("ared"), START_LISTENING_DIGITAL(
+				"srld"), START_LISTENING_ANALOG("srla"), STOP_LISTENING_DIGITAL(
+				"spld"), STOP_LISTENING_ANALOG("spla");
 
 		private String proto;
 
@@ -51,6 +53,10 @@ public class ProtoBuilder {
 
 	private ProtoBuilder(String command) {
 		this.command = command;
+	}
+
+	public String withoutValue() {
+		return "alp://" + command + "/" + pin + "\n";
 	}
 
 	public String withValue(int value) {


### PR DESCRIPTION
Ardulink listeners now can be enabled/disabled via mqtt messages. 
For that to work MqttMain must be called with parameter "-control"
If control is enabled you can enable/disable listeners via mqtt message (e.g. send message "true" to topic "home/devices/ardulink/system/listening/D5/set/value" to instruct Ardulink to publish state changes for digital pin 5
